### PR TITLE
Make it "run" on macOS

### DIFF
--- a/src/chess-backend.c
+++ b/src/chess-backend.c
@@ -1,5 +1,5 @@
 #include <stdlib.h>
-#include <malloc.h>
+#include <malloc/malloc.h>
 
 #include "chess-backend.h"
 #include "cairo-board.h"
@@ -1516,11 +1516,11 @@ void append_san_move(chess_game *game, const char *san_move) {
 
 	size_t cur_len = strlen(game->moves_list);
 	size_t append_len = strlen(append);
-	size_t available = malloc_usable_size(game->moves_list);
+	size_t available = malloc_size(game->moves_list);
 	size_t required = cur_len + append_len;
 	while (available < required) {
-		game->moves_list = (char *) realloc(game->moves_list, malloc_usable_size(game->moves_list) * 2);
-		available = malloc_usable_size(game->moves_list);
+		game->moves_list = (char *) realloc(game->moves_list, malloc_size(game->moves_list) * 2);
+		available = malloc_size(game->moves_list);
 	}
 	memcpy(game->moves_list + cur_len, append, append_len);
 	free(append);

--- a/src/crafty_scanner.h
+++ b/src/crafty_scanner.h
@@ -18,7 +18,7 @@ void crafty_scanner_restart (FILE *input_file);
 typedef unsigned int yy_size_t;
 #endif
 
-extern int crafty_scanner_leng;
+extern yy_size_t crafty_scanner_leng;
 extern char *crafty_scanner_text;
 
 enum _crafty_match_type {

--- a/src/ics_scanner.h
+++ b/src/ics_scanner.h
@@ -7,8 +7,8 @@
 int ics_scanner_lex(void);
 void ics_scanner_restart (FILE *input_file);
 
-extern int ics_scanner_leng;
-YY_BUFFER_STATE ics_scanner__scan_bytes(const char *bytes, int len);
+extern yy_size_t ics_scanner_leng;
+YY_BUFFER_STATE ics_scanner__scan_bytes(const char *bytes, yy_size_t len);
 
 enum _ics_match_type {
 	EOF_TYPE = -1,

--- a/src/main.c
+++ b/src/main.c
@@ -30,7 +30,7 @@
 #include "ics-adapter.h"
 
 /* check that C's multibyte output is supported for use with figurine characters */
-#ifndef __STDC_ISO_10646__
+#if !defined(__STDC_ISO_10646__) && !defined(__APPLE_CC__)
 #error "This compiler/libc doesn't support C's multibyte output!"
 #endif
 

--- a/src/test.c
+++ b/src/test.c
@@ -46,7 +46,7 @@ gboolean test_random_flip(gpointer trash) {
 //	set_last_move("e4");
 //	g_signal_emit_by_name(board, "got_move");
 
-	usleep((__useconds_t) (rand() % (1000000)));
+	usleep((useconds_t) (rand() % (1000000)));
 	debug("Random flipping!\n");
 	g_signal_emit_by_name(board, "flip-board");
 

--- a/src/uci-adapter.c
+++ b/src/uci-adapter.c
@@ -181,7 +181,7 @@ int spawn_uci_engine(bool brainfish) {
 	if (brainfish) {
 		argv[0] = "/usr/local/bin/brainfish";
 	} else {
-		argv[0] = "/usr/bin/stockfish";
+		argv[0] = "/usr/local/bin/stockfish";
 	}
 	argv[1] = NULL;
 

--- a/src/uci_scanner.h
+++ b/src/uci_scanner.h
@@ -11,7 +11,7 @@ void uci_scanner_restart (FILE *input_file);
 typedef unsigned int yy_size_t;
 #endif
 
-extern int uci_scanner_leng;
+extern yy_size_t uci_scanner_leng;
 extern char *uci_scanner_text;
 
 enum _uci_match_type {


### PR DESCRIPTION
⚠️ You don't want to just merge this (as it will break the Linux version), but its a starting point to making it work on macOS. It could feasibly work with clever macro use.

### Building

I got it working using:

```
cmake .
make
./cairo-board
```

It compiles and "runs" with the following caveats:
1. The icons are missing
2. I'm not sure how the networking parts are supposed to work. The UI is there but nothing is in the sidebar.

<img width="1338" alt="screenshot" src="https://user-images.githubusercontent.com/333454/52348445-406f5600-2a1c-11e9-8413-bbebea80b20f.png">


Running on macOS required the following dependencies (maybe more, but it worked after I installed these):

```
brew install stockfish gtk+3 librsvg freetype fontconfig
```
### Changes

* Import <malloc/malloc.h> in place of <malloc.h>
* Use malloc_size instead of malloc_usable_size
* Use useconds_t in place of __useconds_t
* Use yy_size_t consistently for exported values
* Hardcode /usr/local path to stockfish
* Skip multibyte output check (it should "just work")
