### PR TITLE
Fix link error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
+cmake_minimum_required(VERSION 3.6)
+
 project(cairo_board C)
 
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR})
-
-cmake_minimum_required(VERSION 3.6)
 
 set(CMAKE_VERBOSE_MAKEFILE ON)
 
@@ -79,5 +79,5 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(cairo_board ${SOURCE_FILES})
 
-target_link_libraries(cairo_board ${RSVG_LIBRARIES} ${GTK_LIBRARIES} ${FREETYPE_LIBRARIES} ${FONTCONFIG_LIBRARIES} ${GTHREAD_LIBRARIES} pthread)
+target_link_libraries(cairo_board ${RSVG_LIBRARIES} ${GTK_LIBRARIES} ${FREETYPE_LIBRARIES} ${FONTCONFIG_LIBRARIES} ${GTHREAD_LIBRARIES} pthread m)
 


### PR DESCRIPTION
Fixes this error:

```
/usr/bin/ld: CMakeFiles/cairo_board.dir/src/clock-widget.c.o: undefined reference to symbol 'floor@@GLIBC_2.2.5'
/usr/bin/ld: /usr/lib64/libm.so.6: error adding symbols: DSO missing from command line
```

And prevents this warning:

```
CMake Warning (dev) at CMakeLists.txt:1 (project):
  cmake_minimum_required() should be called prior to this top-level project()
  call.  Please see the cmake-commands(7) manual for usage documentation of
  both commands.
```
