### PR TITLE
Fix debug output

### DIFF
--- a/src/uci-adapter.c
+++ b/src/uci-adapter.c
@@ -695,12 +695,16 @@ void *parse_uci_function(void *ignored) {
 }
 
 void write_to_uci(char *message) {
+	char *message1;
 	pthread_mutex_lock(&uci_writer_lock);
 	if (write(uci_in, message, strlen(message)) == -1) {
 		perror("Failed to write to UCI engine ");
 	}
 	pthread_mutex_unlock(&uci_writer_lock);
-	debug("Wrote to UCI: '%s'", message);
+	message1 = (char *)malloc(strlen(message));
+	strncpy(message1, message, strlen(message) - 1);
+	debug("Wrote to UCI: '%s'\n", message1);
+	free(message1);
 }
 
 static void wait_for_engine_ready(void) {


### PR DESCRIPTION
**Replace previous PR**.

Cosmetic change. Create a local copy of UCI messages without line ending for a nicely formatted debug output.

Debug output before change:
```
write_to_uci:704 Wrote to UCI: 'isready
'uci_scanner_lex:24 UCI: Engine ready
write_to_uci:704 Wrote to UCI: 'ucinewgame
'write_to_uci:704 Wrote to UCI: 'isready
'uci_scanner_lex:24 UCI: Engine ready
```

After:
```
write_to_uci:707 Wrote to UCI: 'isready'
uci_scanner_lex:24 UCI: Engine ready
write_to_uci:707 Wrote to UCI: 'ucinewgame'
write_to_uci:707 Wrote to UCI: 'isready'
uci_scanner_lex:24 UCI: Engine ready
```
