### PR TITLE
Add option --engine=ENGINE_PATH

### DIFF
--- a/src/cairo-board.h
+++ b/src/cairo-board.h
@@ -39,6 +39,7 @@ void debug(format, ...) { if (debug_flag) fprintf(stdout, "%s:\033[31m%d\033[0m 
 #define ICS_TEST_HANDLE1	13
 #define ICS_TEST_HANDLE2	14
 #define ICS_TEST_PLAYER1	15
+#define ENGINE				16
 
 // base unicode char for chess fonts
 #define BASE_CHESS_UNICODE_CHAR 0x2654

--- a/src/uci-adapter.c
+++ b/src/uci-adapter.c
@@ -171,18 +171,13 @@ void init_uci_adapter() {
 	pthread_create(&uci_manager_thread, NULL, uci_manager_function, NULL);
 }
 
-int spawn_uci_engine(bool brainfish) {
+int spawn_uci_engine(char *engine) {
 	GPid child_pid;
 	GError *spawnError = NULL;
 
 	gchar *argv[2];
-
-	//TODO: can we discover these from $PATH?
-	if (brainfish) {
-		argv[0] = "/usr/local/bin/brainfish";
-	} else {
-		argv[0] = "/usr/bin/stockfish";
-	}
+	argv[0] = (gchar *)malloc(strlen(engine));
+	strncpy(argv[0], engine, strlen(engine));
 	argv[1] = NULL;
 
 	gboolean ret = g_spawn_async_with_pipes(g_get_home_dir(), argv, NULL, G_SPAWN_DEFAULT, NULL, NULL, &child_pid,
@@ -205,10 +200,6 @@ int spawn_uci_engine(bool brainfish) {
 	write_to_uci("setoption name Hash value 2048");
 	write_to_uci("setoption name Ponder value true");
 	write_to_uci("setoption name Skill Level value 20");
-	if (brainfish) {
-		// TODO: check if this needs to be an absolute path
-		write_to_uci("setoption name BookPath value /home/hts/brainfish/Cerebellum_Light.bin");
-	}
 	wait_for_engine_ready();
 	return 0;
 }

--- a/src/uci-adapter.h
+++ b/src/uci-adapter.h
@@ -8,7 +8,7 @@ typedef enum {
 } UCI_MODE;
 
 void cleanup_uci(void);
-int spawn_uci_engine(bool brainfish);
+int spawn_uci_engine(char *engine);
 void write_to_uci(char *message);
 void user_move_to_uci(char *move, bool analyse);
 void start_new_uci_game(unsigned int time, UCI_MODE mode);


### PR DESCRIPTION
Add option `--engine=/path/to/engine`.

Test, without option, when default engine doesn't exist:
```
[roland@localhost cairo-board-rchastain2 (engine_option)]$ ./cairo_board --debug
main:2348 Debug info enabled
main:2362 Engine not specified, will use default engine /usr/bin/stockfish
main:2440 Loaded CSS
main:2721 Successfully loaded font in FontConfig! DSEG7 Classic Bold
spawn_uci_engine_idle:2222 Spawning UCI engine...

** (cairo_board:242775): ERROR **: 07:44:32.317: spawn_uci_engine FAILED L’exécution du processus fils « /usr/bin/stockfish » a échoué (Aucun fichier ou dossier de ce type)
Trappe pour point d'arrêt et de trace (core dumped)
```

Test with option:
```
[roland@localhost cairo-board-rchastain2 (engine_option)]$ ./cairo_board --debug --engine="/home/roland/Applications/cheese/331/cheese-331-linux"
main:2348 Debug info enabled
main:2440 Loaded CSS
main:2721 Successfully loaded font in FontConfig! DSEG7 Classic Bold
spawn_uci_engine_idle:2222 Spawning UCI engine...
[parse UCI thread] - Starting UCI parser
write_to_uci:697 Wrote to UCI: 'uci'
[UCI manager thread] - Starting UCI manager
uci_scanner_lex:68 Not yet matched from UCI engine: Cheese 3.3.1 by Patrice Duhamel
uci_scanner_lex:29 UCI: Engine ID name from UCI engine id name Cheese 3.3.1
parse_uci_buffer:641 Got UCI Name: id name Cheese 3.3.1
uci_scanner_lex:34 UCI: Engine ID author from UCI engine id author Patrice Duhamel
parse_uci_buffer:647 Got UCI Author: id author Patrice Duhamel
parse_option:285 Option Hash, type: spin default 32 min 1 max 65536
parse_option:285 Option Ponder, type: check default false
parse_option:285 Option OwnBook, type: check default false
parse_option:285 Option Book, type: string default cheesebook-30.bin
...
uci_scanner_lex:19 UCI: All options sent, engine ready in UCI mode
spawn_uci_engine:197 UCI OK!
```